### PR TITLE
fix: Remove subtitles and center content in category cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -412,15 +412,17 @@ src="https://www.facebook.com/tr?id=482675157669768&ev=PageView&noscript=1"
             display: flex;
             flex-direction: column;
             align-items: center;
+            justify-content: center;
             border: 1px solid #e9e9e9;
             flex: 0 0 auto;
             width: 200px;
+            gap: 0.5rem;
         }
         .category:hover { transform: translateY(-4px); box-shadow: 0 6px 16px rgba(0,0,0,0.12); border-color: var(--primary-color); }
-        .category-icon-wrapper { background-color: var(--primary-color); width: 60px; height: 60px; border-radius: 12px; display: flex; align-items: center; justify-content: center; margin-bottom: 1rem; transition: transform 0.2s ease; }
+        .category-icon-wrapper { background-color: var(--primary-color); width: 60px; height: 60px; border-radius: 12px; display: flex; align-items: center; justify-content: center; transition: transform 0.2s ease; }
         .category:hover .category-icon-wrapper { transform: scale(1.05); }
         .category i.category-icon-fa { font-size: 1.8rem; color: white; display: block; line-height: 1; }
-        .category-name { font-size: 1.1rem; font-weight: 600; color: var(--text-color); line-height: 1.3; margin-bottom: 0.35rem; }
+        .category-name { font-size: 1.1rem; font-weight: 600; color: var(--text-color); line-height: 1.3; }
         .category-subtitle { font-size: 0.85rem; color: #666666; line-height: 1.4; }
 
         .featured-section-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.5rem; margin-top: 2.5rem; }
@@ -1214,22 +1216,18 @@ src="https://www.facebook.com/tr?id=482675157669768&ev=PageView&noscript=1"
                 <div class="category" onclick="navigateTo('products', 'course')">
                     <div class="category-icon-wrapper"><i class="fas fa-graduation-cap category-icon-fa" aria-hidden="true"></i></div>
                     <p class="category-name">Course</p>
-                    <p class="category-subtitle" id="category-count-course">0 Premium Courses</p>
                 </div>
                 <div class="category" onclick="navigateTo('products', 'subscription')">
                     <div class="category-icon-wrapper"><i class="fas fa-key category-icon-fa" aria-hidden="true"></i></div>
                     <p class="category-name">Subscription</p>
-                    <p class="category-subtitle" id="category-count-subscription">0 Premium Services</p>
                 </div>
                 <div class="category" onclick="navigateTo('products', 'software')">
                     <div class="category-icon-wrapper"><i class="fas fa-laptop-code category-icon-fa" aria-hidden="true"></i></div>
                     <p class="category-name">Software</p>
-                    <p class="category-subtitle" id="category-count-software">0 Bundle Packages</p>
                 </div>
                 <div class="category" onclick="navigateTo('products', 'ebook')">
                     <div class="category-icon-wrapper"><i class="fas fa-book-open category-icon-fa" aria-hidden="true"></i></div>
                     <p class="category-name">Ebook</p>
-                    <p class="category-subtitle" id="category-count-ebook">0 Digital Guides</p>
                 </div>
             </section>
 


### PR DESCRIPTION
- Removed the subtitle text from the product category cards.
- Adjusted the CSS to ensure the icon and category name are perfectly centered within the card.

---

🎨 This PR simplifies the product category cards by removing subtitle text and improving the visual centering of content within each card.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **HTML Structure**: Removed subtitle paragraphs (`category-subtitle`) from all four product category cards (Course, Subscription, Software, Ebook)
- **CSS Layout**: Added `justify-content: center` and `gap: 0.5rem` to the `.category` class for better vertical centering
- **Spacing Adjustments**: Removed `margin-bottom: 1rem` from `.category-icon-wrapper` and `margin-bottom: 0.35rem` from `.category-name`

### Technical Implementation
```mermaid
flowchart TD
    A[Category Card Container] --> B[Icon Wrapper]
    A --> C[Category Name]
    A -.-> D[Category Subtitle - REMOVED]
    
    B --> E[FontAwesome Icon]
    
    F[CSS Changes] --> G[justify-content: center]
    F --> H[gap: 0.5rem]
    F --> I[Removed margin-bottom values]
    
    style D fill:#ffcccc,stroke:#ff0000,stroke-dasharray: 5 5
    style F fill:#e1f5fe
```

### Impact
- **Visual Consistency**: Cards now have a cleaner, more focused appearance without the dynamic subtitle counts
- **Layout Improvement**: Content is properly centered both horizontally and vertically within each card
- **Maintenance Reduction**: Eliminates the need to maintain and update subtitle counters (e.g., "0 Premium Courses")

</details>

_Created with [Palmier](https://www.palmier.io)_